### PR TITLE
fix(doc): Correct API documentation links in README files

### DIFF
--- a/services/convoai/README.md
+++ b/services/convoai/README.md
@@ -29,7 +29,7 @@ Agora's Conversational AI Engine redefines human-computer interaction, breaking 
 
 ## API Definition
 
-For more api details, please refer to the [API Documentation](https://doc.shengwang.cn//api-ref/convoai/go/go-api/overview)
+For more api details, please refer to the [API Documentation](https://doc.shengwang.cn/api-ref/convoai/go/go-api/overview)
 
 ## API Call Examples
 

--- a/services/convoai/README_ZH.md
+++ b/services/convoai/README_ZH.md
@@ -29,7 +29,7 @@
 
 ## API定义
 
-更多API详情，请参考 [API文档](https://doc.shengwang.cn//api-ref/convoai/go/go-api/overview)
+更多API详情，请参考 [API文档](https://doc.shengwang.cn/api-ref/convoai/go/go-api/overview)
 
 ## API调用示例
 


### PR DESCRIPTION
This pull request includes minor updates to the `README` files in the `services/convoai` directory. The changes correct the URL for the API documentation link.

Changes to `README` files:

* [`services/convoai/README.md`](diffhunk://#diff-208214f70ddf6dc7eef94948575f0f6b2fa9facad07f589ea56a27730151c1a2L32-R32): Corrected the URL for the API documentation link by removing an extra slash.
* [`services/convoai/README_ZH.md`](diffhunk://#diff-c0e50fc0e6f4b85ae706621b5d6e0d2115b76f08a152f0b8949dd49a0af36684L32-R32): Corrected the URL for the API documentation link by removing an extra slash.